### PR TITLE
Updated python-imaging (deprecated) to python-pil

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Command: sudo apt-get install python-smbus
 
 You need the Python Imaging Library (PIL) which adds image processing capabilities to your Python interpreter.
 
-Command: sudo apt-get python-imaging
+Command: sudo apt-get install python-pil
 
 After executing the four commands above now you have to install the Adafruit Python LED Backpack.
 
@@ -100,13 +100,13 @@ Step 1: Create a folder in your home directory (/pi/home/) with the name “led�
 
 Step 2: Download the Adafruit Python LED Backpack with the following command.
 
-Command: sudo git clone https://github.com/adafruit/Adafruit_Python_LED_Backpack.git
+Command: git clone https://github.com/adafruit/Adafruit_Python_LED_Backpack.git
 
 After successfully downloading the library go into the led folder “/home/pi/led/Adafruit_Python_LED_Backpack” and execute the following command to install the library on your Raspberry Pi
 
 Command: sudo python setup.py install
 
-To execute the Adafruit LED test example go into the folder “/home/pi/led/Adafruit_Python_LED_Backpack/example” and execute the “matrix8x8_test.py” program if the I2C address is correct for your LED matrix.
+To execute the Adafruit LED test example go into the folder “/home/pi/led/Adafruit_Python_LED_Backpack/examples” and execute the “matrix8x8_test.py” program if the I2C address is correct for your LED matrix.
 
 Command: python matrix8x8_test.py
 


### PR DESCRIPTION
``python-imaging`` module is not available, but ``python-pil`` can replace it. Also, there is no need to use ``sudo`` with ``git``. Cheers!